### PR TITLE
Adding a patch such that orb slam uses opencv3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 ExternalProject_Add(orb_slam_2_src
   GIT_REPOSITORY git@github.com:raulmur/ORB_SLAM2.git
   UPDATE_COMMAND ""
+  PATCH_COMMAND cd ../orb_slam_2_src/ && git apply ${CMAKE_CURRENT_SOURCE_DIR}/opencv3_dep.patch
   CONFIGURE_COMMAND
       # Configuring DBoW2
       mkdir -p ../orb_slam_2_src/Thirdparty/DBoW2/build && 

--- a/opencv3_dep.patch
+++ b/opencv3_dep.patch
@@ -1,0 +1,25 @@
+From 3e2a4ab381c2ce2cc0712390463af63f342f7483 Mon Sep 17 00:00:00 2001
+From: Alex Millane <alex.millane@gmail.com>
+Date: Wed, 21 Dec 2016 10:34:46 +0100
+Subject: [PATCH] Changed opencv2 to opencv3 dep
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fadce0f..b524d2e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,7 @@ endif()
+ 
+ LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)
+ 
+-find_package(OpenCV 2.4.3 REQUIRED)
++find_package(OpenCV 3.1 REQUIRED)
+ find_package(Eigen3 3.1.0 REQUIRED)
+ find_package(Pangolin REQUIRED)
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
As advertised. With this PR I can finally use orb slam successfully as a library in kinetic. I very much doubt that this will work in indigo, likely due to this patch, but I'll fix that at a later date when someone complains.